### PR TITLE
constellate-R-notebooks

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: constellate-R-notebooks
+  description: Auto-generated catalog-info.yaml.
+  tags:
+  - unknown
+spec:
+  type: unknown
+  owner: group:possible-orphan
+  lifecycle: unknown


### PR DESCRIPTION
This PR adds a `catalog-info.yaml` file to Backstage when merged. If your repo is GitHub Only, this will not be picked up Backstage presently.